### PR TITLE
Show Hide Project Tile Feature

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -396,6 +396,11 @@ a {
 
 .show-hide-project-list-button {
   height: 3rem;
+  font-size: 1.75rem;
+  cursor: pointer;
+  background-color: rgb(60, 60, 60);
+  color: white;
+  border: 2px solid rgb(133, 133, 133);
 }
 
 #footer {

--- a/src/App.css
+++ b/src/App.css
@@ -271,6 +271,7 @@ hr.rounded {
   gap: 0;
   margin: 0;
   border: 3px solid gray;
+  transition: height 0.3s ease, transform 0.3s ease, opacity 0.3s ease;
 }
 
 .project-tile {
@@ -279,6 +280,12 @@ hr.rounded {
 
 .project-tile-hidden {
   height: 30.625rem; /* 490px; */
+}
+
+.teased-tile {
+  height: 15.3125rem; /* 245px - Only show half */
+  overflow: hidden;
+  opacity: 0.5;
 }
 
 .image-and-list-container {

--- a/src/App.css
+++ b/src/App.css
@@ -255,7 +255,6 @@ hr.rounded {
   display: grid;
   justify-content: center;
   grid-template-columns: 70vw;
-  grid-auto-rows: 43.75rem; /* 700px; */
   row-gap: 100px;
 }
 
@@ -394,6 +393,10 @@ a {
   height: 0; 
   visibility: hidden; 
   overflow: hidden; 
+}
+
+.show-hide-project-list-button {
+  height: 3rem;
 }
 
 #footer {

--- a/src/App.css
+++ b/src/App.css
@@ -280,10 +280,16 @@ hr.rounded {
   height: 30.625rem; /* 490px; */
 }
 
+/* Exclude title and description when teased. */
 .teased-tile {
-  height: 17.8125rem; /* 285px - exclude title and description */
+  height: 17.8125rem; /* 285px */
   overflow: hidden;
   opacity: 0.5;
+}
+
+.teased-tile .project-title,
+.teased-tile .show-hide-description-button {
+  visibility: hidden;
 }
 
 .image-and-list-container {
@@ -524,7 +530,6 @@ textarea:focus:invalid,
 
   #project-grid {
     grid-template-columns: 90vw;
-    grid-auto-rows: 56.25rem; /* 900px; */
   }
 
   .project-tile {
@@ -533,6 +538,10 @@ textarea:focus:invalid,
   
   .project-tile-hidden {
     height: 43.125rem; /* 690px; */
+  }
+
+  .teased-tile {
+    height: 29.6875rem; /* 475px - exclude title and description */
   }
 
   .image-and-list-container {

--- a/src/App.css
+++ b/src/App.css
@@ -265,7 +265,6 @@ hr.rounded {
 .project-tile, .project-tile-hidden {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   width: 100%;
   gap: 0;
   margin: 0;
@@ -282,7 +281,7 @@ hr.rounded {
 }
 
 .teased-tile {
-  height: 15.3125rem; /* 245px - Only show half */
+  height: 17.8125rem; /* 285px - exclude title and description */
   overflow: hidden;
   opacity: 0.5;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -744,3 +744,11 @@ textarea:focus:invalid,
     font-size: 1rem;
   }
 }
+
+/* 400px */
+@media screen and (max-width: 25rem) {
+  .teased-tile,
+  .teased-tile .image-and-list-container {
+    height: 7.1875rem; /* 115px */
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -564,7 +564,10 @@ textarea:focus:invalid,
     height: 43.125rem; /* 690px; */
   }
 
-  /* Exclude list-container, title, and description for teased-tile in mobile/tablet views. */
+  /* 
+    Exclude list-container, title, and description for teased-tile in mobile/tablet views.
+    Reduce height again at break points for 800px, 600px, and 400px. 
+  */
   .teased-tile,
   .teased-tile .image-and-list-container {
     height: 18.125rem; /* 290px */

--- a/src/App.css
+++ b/src/App.css
@@ -548,7 +548,8 @@ textarea:focus:invalid,
     font-size: 2rem;
   }
 
-  #project-grid-heading {
+  #project-grid-heading, 
+  #footer {
     width: 90vw;
   }
 
@@ -593,10 +594,6 @@ textarea:focus:invalid,
 
   .list-container {
     height: 50%;
-  }
-
-  #footer {
-    width: 90vw;
   }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -673,6 +673,7 @@ textarea:focus:invalid,
   .footer-photo {
     margin-block-end: 20px;
     margin-inline-start: 0;
+    width: 50%;
   }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -288,7 +288,7 @@ hr.rounded {
   opacity: 0.6;
 }
 
-.teased-tile .project-title,
+.teased-tile .project-title-anchor,
 .teased-tile .show-hide-description-button {
   visibility: hidden;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -651,6 +651,11 @@ textarea:focus:invalid,
     margin-inline-start: 0;
   }
 
+  .teased-tile,
+  .teased-tile .image-and-list-container {
+    height: 14.0625rem; /* 225px */
+  }
+
   .list-container {
     padding-inline-end: 2%;
   }
@@ -703,6 +708,11 @@ textarea:focus:invalid,
 
   .header-photo, .footer-photo {
     width: 15.5rem; /* 248px - Same width as intro-link. */
+  }
+
+  .teased-tile,
+  .teased-tile .image-and-list-container {
+    height: 9.375rem; /* 150px */
   }
 
   #skills-title {

--- a/src/App.css
+++ b/src/App.css
@@ -564,8 +564,18 @@ textarea:focus:invalid,
     height: 43.125rem; /* 690px; */
   }
 
-  .teased-tile {
-    height: 29.6875rem; /* 475px - exclude title and description */
+  /* Exclude list-container, title, and description for teased-tile in mobile/tablet views. */
+  .teased-tile,
+  .teased-tile .image-and-list-container {
+    height: 18.125rem; /* 290px */
+  }
+
+  .teased-tile .list-container {
+    visibility: hidden;
+  }
+
+  .teased-tile .project-image {
+    height: 100%;
   }
 
   .image-and-list-container {

--- a/src/App.css
+++ b/src/App.css
@@ -735,7 +735,9 @@ textarea:focus:invalid,
     align-items: flex-start;
   }
 
-  .project-title {
+  .project-title,
+  .show-hide-project-list-button-open,
+  .show-hide-project-list-button-closed {
     font-size: 1.25rem;
   }
 

--- a/src/App.css
+++ b/src/App.css
@@ -404,13 +404,22 @@ a {
   text-align: center;
 }
 
-.show-hide-project-list-button {
+.show-hide-project-list-button-open,
+.show-hide-project-list-button-closed {
   height: 3rem;
   font-size: 1.75rem;
   cursor: pointer;
   background-color: rgb(60, 60, 60);
   color: white;
   border: 2px solid rgb(133, 133, 133);
+}
+
+.show-hide-project-list-button-open {
+  margin-block-start: 100px;
+}
+
+.show-hide-project-list-button-closed {
+  margin-block-start: 0;
 }
 
 #footer {

--- a/src/App.css
+++ b/src/App.css
@@ -282,14 +282,25 @@ hr.rounded {
 
 /* Exclude title and description when teased. */
 .teased-tile {
+  position: relative;
   height: 17.8125rem; /* 285px */
   overflow: hidden;
-  opacity: 0.5;
+  opacity: 0.6;
 }
 
 .teased-tile .project-title,
 .teased-tile .show-hide-description-button {
   visibility: hidden;
+}
+
+.teased-tile::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none; /* allow clicks through */
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.8));
 }
 
 .image-and-list-container {

--- a/src/App.css
+++ b/src/App.css
@@ -400,6 +400,10 @@ a {
   overflow: hidden; 
 }
 
+.show-hide-project-list-button-container {
+  text-align: center;
+}
+
 .show-hide-project-list-button {
   height: 3rem;
   font-size: 1.75rem;

--- a/src/App.css
+++ b/src/App.css
@@ -573,12 +573,12 @@ textarea:focus:invalid,
     height: 18.125rem; /* 290px */
   }
 
-  .teased-tile .list-container {
-    visibility: hidden;
-  }
-
   .teased-tile .project-image {
     height: 100%;
+  }
+
+  .teased-tile .list-container {
+    visibility: hidden;
   }
 
   .image-and-list-container {

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -2,10 +2,13 @@ import { useState } from 'react';
 import projectArray from './ProjectArray.jsx';
 
 export default function ProjectGrid() {
-  // Track the expanded state of each project using an object.
-  const [expandedProjects, setExpandedProjects] = useState({});
-  const [isReversed, setIsReversed] = useState(false);
   const [currentArray, setCurrentArray] = useState(projectArray);
+  const [expandedProjects, setExpandedProjects] = useState({}); // Track the expanded state of each project using an object.
+  const [isReversed, setIsReversed] = useState(false);
+  const [showAllTiles, setShowAllTiles] = useState(false);
+
+  const teasedTileCount = 2;
+  const displayedTiles = showAllTiles ? currentArray : currentArray.slice(0, teasedTileCount);
 
   // Toggle the expanded state for the clicked project.
   const toggleExpanded = (projectId) => {
@@ -58,7 +61,7 @@ export default function ProjectGrid() {
 
         <div id="project-grid">
           {
-            currentArray.map((project) => (
+            displayedTiles.map((project) => (
               <div 
                 className={expandedProjects[project.id] ? "project-tile" : "project-tile-hidden"} 
                 key={project.id}

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -149,6 +149,9 @@ export default function ProjectGrid() {
               </div>
             ))
           } 
+          <button onClick={() => setShowAllTiles(!showAllTiles)} className="show-hide-project-list-button">
+            {showAllTiles ? 'Hide' : 'Show All'}
+          </button>
         </div>  
       </section>
     </main>

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -150,7 +150,7 @@ export default function ProjectGrid() {
             ))
           } 
           <button onClick={() => setShowAllTiles(!showAllTiles)} className="show-hide-project-list-button">
-            {showAllTiles ? 'Hide' : 'Show All'}
+            {showAllTiles ? 'Hide Projects' : 'Show All Projects'}
           </button>
         </div>  
       </section>

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -63,7 +63,7 @@ export default function ProjectGrid() {
           {
             displayedTiles.map((project) => (
               <div 
-                className={expandedProjects[project.id] ? "project-tile" : "project-tile-hidden"} 
+                className={`${expandedProjects[project.id] ? "project-tile" : "project-tile-hidden"} ${!showAllTiles && project.id === 1 ? 'teased-tile' : ''}`} 
                 key={project.id}
               >
                 <div className="image-and-list-container">

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -63,7 +63,10 @@ export default function ProjectGrid() {
           {
             displayedTiles.map((project) => (
               <div 
-                className={`${expandedProjects[project.id] ? "project-tile" : "project-tile-hidden"} ${!showAllTiles && project.id === 1 ? 'teased-tile' : ''}`} 
+                className={`
+                  ${expandedProjects[project.id] ? "project-tile" : "project-tile-hidden"} 
+                  ${!showAllTiles && (project.id === 1 || project.id === currentArray.length - 2) ? 'teased-tile' : ''}
+                `} 
                 key={project.id}
               >
                 <div className="image-and-list-container">

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -153,9 +153,11 @@ export default function ProjectGrid() {
             ))
           } 
         </div>
-        <button onClick={() => setShowAllTiles(!showAllTiles)} className="show-hide-project-list-button">
-          {showAllTiles ? 'Hide Projects' : 'Show All Projects'}
-        </button>
+        <div className="show-hide-project-list-button-container">
+          <button onClick={() => setShowAllTiles(!showAllTiles)} className="show-hide-project-list-button">
+            {showAllTiles ? 'Hide Projects' : 'Show All Projects'}
+          </button>
+        </div>
       </section>
     </main>
   );

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -154,7 +154,10 @@ export default function ProjectGrid() {
           } 
         </div>
         <div className="show-hide-project-list-button-container">
-          <button onClick={() => setShowAllTiles(!showAllTiles)} className="show-hide-project-list-button">
+          <button 
+            onClick={() => setShowAllTiles(!showAllTiles)} 
+            className={showAllTiles ? "show-hide-project-list-button-open" : "show-hide-project-list-button-closed"}
+          >
             {showAllTiles ? 'Hide Projects' : 'Show All Projects'}
           </button>
         </div>

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -42,6 +42,13 @@ export default function ProjectGrid() {
     });
   };
 
+  const toggleProjectGridExpansion = () => {
+    setShowAllTiles(!showAllTiles);
+
+    const orderSelect = document.getElementById('order-select');
+    orderSelect.focus({ preventScroll: true });
+  }
+
   return (
     <main>
       <section id="project-grid-container">
@@ -155,7 +162,7 @@ export default function ProjectGrid() {
         </div>
         <div className="show-hide-project-list-button-container">
           <button 
-            onClick={() => setShowAllTiles(!showAllTiles)} 
+            onClick={toggleProjectGridExpansion} 
             className={showAllTiles ? "show-hide-project-list-button-open" : "show-hide-project-list-button-closed"}
             aria-expanded={showAllTiles}
             aria-controls="project-grid"

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -157,6 +157,8 @@ export default function ProjectGrid() {
           <button 
             onClick={() => setShowAllTiles(!showAllTiles)} 
             className={showAllTiles ? "show-hide-project-list-button-open" : "show-hide-project-list-button-closed"}
+            aria-expanded={showAllTiles}
+            aria-controls="project-grid"
           >
             {showAllTiles ? 'Hide Projects' : 'Show All Projects'}
           </button>

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -26,7 +26,7 @@ export default function ProjectGrid() {
     setTimeout(() => {
       projectGrid.classList.remove('project-grid-reversed');
     }, 1000);
-  }
+  };
 
   const toggleProjectGridOrder = () => {
     // Animate the project grid when it is reordered.
@@ -47,7 +47,7 @@ export default function ProjectGrid() {
 
     const orderSelect = document.getElementById('order-select');
     orderSelect.focus({ preventScroll: true });
-  }
+  };
 
   return (
     <main>

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -3,7 +3,7 @@ import projectArray from './ProjectArray.jsx';
 
 export default function ProjectGrid() {
   const [currentArray, setCurrentArray] = useState(projectArray);
-  const [expandedProjects, setExpandedProjects] = useState({}); // Track the expanded state of each project using an object.
+  const [expandedDescriptions, setExpandedDescriptions] = useState({}); // Track the expanded state of each project description using an object.
   const [isReversed, setIsReversed] = useState(false);
   const [showAllTiles, setShowAllTiles] = useState(false);
 
@@ -11,8 +11,8 @@ export default function ProjectGrid() {
   const displayedTiles = showAllTiles ? currentArray : currentArray.slice(0, teasedTileCount);
 
   // Toggle the expanded state for the clicked project.
-  const toggleExpanded = (projectId) => {
-    setExpandedProjects((prevState) => ({
+  const toggleExpandedDescription = (projectId) => {
+    setExpandedDescriptions((prevState) => ({
       ...prevState,
       [projectId]: !prevState[projectId] // Toggle the expanded state for the specific project.
     }));
@@ -71,7 +71,7 @@ export default function ProjectGrid() {
             displayedTiles.map((project) => (
               <div 
                 className={`
-                  ${expandedProjects[project.id] ? "project-tile" : "project-tile-hidden"} 
+                  ${expandedDescriptions[project.id] ? "project-tile" : "project-tile-hidden"} 
                   ${!showAllTiles && (project.id === 1 || project.id === currentArray.length - 2) ? 'teased-tile' : ''}
                 `} 
                 key={project.id}
@@ -140,18 +140,18 @@ export default function ProjectGrid() {
                 {/* Button to toggle the description */}
                 <button 
                   className="show-hide-description-button" 
-                  onClick={() => toggleExpanded(project.id)}
-                  aria-expanded={expandedProjects[project.id] || "false"}
+                  onClick={() => toggleExpandedDescription(project.id)}
+                  aria-expanded={expandedDescriptions[project.id] || "false"}
                   aria-controls={`project-desc-${project.id}`}
                 >
-                  {expandedProjects[project.id] ? 'Hide Description' : 'Show Description'}
+                  {expandedDescriptions[project.id] ? 'Hide Description' : 'Show Description'}
                 </button>
 
                 {/* Conditional rendering of the project description */}
-                {expandedProjects[project.id] && (
+                {expandedDescriptions[project.id] && (
                   <p
                     id={`project-desc-${project.id}`}
-                    className={expandedProjects[project.id] ? "project-description" : "project-description-hidden"}
+                    className={expandedDescriptions[project.id] ? "project-description" : "project-description-hidden"}
                   >
                     {project.description}
                   </p>

--- a/src/Components/ProjectGrid.jsx
+++ b/src/Components/ProjectGrid.jsx
@@ -152,10 +152,10 @@ export default function ProjectGrid() {
               </div>
             ))
           } 
-          <button onClick={() => setShowAllTiles(!showAllTiles)} className="show-hide-project-list-button">
-            {showAllTiles ? 'Hide Projects' : 'Show All Projects'}
-          </button>
-        </div>  
+        </div>
+        <button onClick={() => setShowAllTiles(!showAllTiles)} className="show-hide-project-list-button">
+          {showAllTiles ? 'Hide Projects' : 'Show All Projects'}
+        </button>
       </section>
     </main>
   );


### PR DESCRIPTION
This update saw me develop a way to hide the majority of the project tiles by default to reduce the amount of scrolling on the page, showing 1.5 tiles as a teaser with a ‘show all projects’ button to reveal the rest. When all tiles are revealed, the button switches to a 'hide' button, and clicking it will bring the project list back to the default view. 